### PR TITLE
Fastq pipe minimap2

### DIFF
--- a/modules/local/minimap2/main.nf
+++ b/modules/local/minimap2/main.nf
@@ -22,7 +22,7 @@ process MINIMAP2 {
     """
     # combine fastq/minimap2/sort to overlap IO with computations
     samtools fastq -T 'MM,ML' ${input_file} | \\
-        minimap2 -ax $minimap2_preset -t $task.cpus "${ref_fasta}" - | \\
+        minimap2 -y -ax $minimap2_preset -t $task.cpus "${ref_fasta}" - | \\
         samtools sort -@ $task.cpus > "${meta.id}_${meta.sample}_mapped.bam"
     """
 }


### PR DESCRIPTION
* pipes `samtools fastq` directly into `minimap2`
    * some benefits for larger bams, but minimal difference for smaller bams.
* adds `-y` to `minimap2`
* moves `minimap2` preset setting to a groovy block seperate to the bash block.